### PR TITLE
[style] : ListRow 컴포넌트 제작

### DIFF
--- a/src/components/common/ListRow/index.tsx
+++ b/src/components/common/ListRow/index.tsx
@@ -1,0 +1,101 @@
+import { KeyOfTypo, KeyOfPalette } from "@/styles/theme";
+import styled from "@emotion/styled";
+import { ComponentProps, ReactNode } from "react"
+import { Text } from "@/components/common/Text";
+
+interface ListRowProps extends ComponentProps<'div'> {
+  rightElement: ReactNode;
+  leftImage: JSX.Element;
+  mainText: ReactNode;
+  textTypo?: KeyOfTypo;
+  textColor?: KeyOfPalette;
+  imageGap?: number;
+  gap?: number;
+  subElement?: ReactNode;
+  fullWidth?: boolean;
+}
+
+/**
+ * @param rightElement : 오른쪽에 위치시킬 React Element
+ * @param leftImage : 왼쪽에 위치시킬 Image 컴포넌트 
+ * @param mainText: 왼쪽에 위치시킬 main Text 
+ * @param textTypo : main Text에 적용할 typo
+ * @param textColor: main Text에 적용시킬 color 
+ * @param imageGap : image와 Text 사이의 gap
+ * @param gap : text와 subText 사이의 gap 결정
+ * @param subElement: main Text 아래에 위치할 React Element
+ * @param fullWidth : true로 설정할 경우 width: 100%, 기본값 true
+ */
+
+const ListRow = ({
+  rightElement,
+  leftImage,
+  mainText,
+  textTypo = 'Body_13',
+  textColor = 'BLACK',
+  gap = 4,
+  imageGap = 8,
+  subElement,
+  fullWidth = true,
+  ...props
+}: ListRowProps) => {
+  return (
+    //TODO: Padding 컴포넌트 생성되면 추후 Padding도 추가할 예정입니다. 
+    <MainFlexBox fullWidth={fullWidth} {...props}>
+      <SubFlexBox gap={imageGap}>
+        {leftImage}
+        <TextFlexBox gap={gap}>
+          <StyledText text={mainText} typo={textTypo} color={textColor} />
+          {subElement && subElement}
+        </TextFlexBox>
+      </SubFlexBox>
+      {rightElement}
+    </MainFlexBox >
+  )
+}
+
+const MainFlexBox = styled.div<{ fullWidth: boolean }>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: ${({ fullWidth }) => fullWidth ? '100%' : undefined};
+`
+
+const SubFlexBox = styled.div<{ gap: number }>`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: ${({ gap }) => `${gap}px`};
+`
+
+const TextFlexBox = styled.div<{ gap: number }>`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: ${({ gap }) => `${gap}px`};
+  align-items: flex-start;
+`
+
+const StyledText = ({
+  text,
+  typo,
+  color,
+  ...props
+}: {
+  text: ReactNode;
+  typo: KeyOfTypo;
+  color: KeyOfPalette;
+} & ComponentProps<'div'>) => {
+  return (
+    <>
+      {typeof text === 'string' ? (
+        <Text typo={typo} color={color} {...props}>
+          {text}
+        </Text>
+      ) : (
+        <div {...props}>{text}</div>
+      )}
+    </>
+  );
+};
+export default ListRow


### PR DESCRIPTION
## 이슈번호
- close #5 

## 작업내용 설명
ListRow 컴포넌트를 만들었습니다 ~
### Props 설명
```ts
interface ListRowProps extends ComponentProps<'div'> {
  rightElement: ReactNode;
  leftImage: JSX.Element;
  mainText: ReactNode;
  textTypo?: KeyOfTypo;
  textColor?: KeyOfPalette;
  imageGap?: number;
  gap?: number;
  subElement?: ReactNode;
  fullWidth?: boolean;
}
```
- rightElement: 맨 오른쪽에 들어갈 React Element
- leftImage : ListRow의 맨 왼쪽에 들어갈 image 컴포넌트
- mainText: ListRow 최상단에 작성될 Text
- textTypo : `mainText`를 꾸며줄 수 있는 typo 설정
- textColor : `mainText`를 꾸며줄 수 있는 color 설정
- imageGap : `leftImage`와 `Text` 컴포넌트 사이의 flex gap을 설정합니다.
- gap : `mainText`와 `subElment` 사이의 flex gap을 설정합니다.
- subElement : `mainText` 하단에 넣을 요소를 결정합니다. 
- fullWidth : ListRow 컴포넌트의 가로 길이를 100%로 할 것인지 아닌지 결정합니다.

### 예시코드
```ts
<ListRow leftImage={<img src='..' />} mainText='김유진' 
 rightElement={<button>클릭클릭!</button>} fullWidth={false} subElement={<button>친구 추가</button>} />
```
![스크린샷 2023-09-08 오전 12 52 52](https://github.com/prgrms-fe-devcourse/FEDC4_PETTALK_Yrnana/assets/67894159/48c75e25-14be-4436-b13c-e6f57fa54952)

이 코드는 채팅창 구현이나, 게시글 상세보기에 사용하면 좋을 것 같네용 ~

```ts
<ListRow leftImage={<img src='..' />} mainText='김유진 유저' rightElement={<button>버튼인 척 하는 중!</button>} textColor="GRAY700" textTypo="Body_16" imageGap={15}/>
```
![스크린샷 2023-09-08 오전 12 52 58](https://github.com/prgrms-fe-devcourse/FEDC4_PETTALK_Yrnana/assets/67894159/5ab84c35-1859-4430-99d2-4fee19c9e693)
`textTypo`와 `textColor`를 이용하여 `mainText` 의 크기를 키우고, 색도 바꿔봤어요~ 이 컴포넌트는 친구 목록에서 이용하면 좋겠네요 👍

## 리뷰어에게 한마디
@cloud0406 님이 만들어주시는 FlexBox 컴포넌트가 완성되면 현재 styled-component로 만들어 놓은 임시 컴포넌트를 대체하여 리팩토링을 진행할 예정입니다.
또한, profileimage같은 경우 임시로 만들어 둔 컴포넌트를 넣어서 테스트한 것인데 @JeongWuk 님이 만들어 주시는 ProfileImage 컴포넌트로 넣으면 매우매우 굿일 것 같습니다! 