### PR TITLE
[Style] : postCard 컴포넌트 제작

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "printWidth": 80,
+  "printWidth": 100,
   "tabWidth": 2,
   "singleQuote": true,
   "trailingComma": "all",

--- a/src/components/common/flexBox/index.tsx
+++ b/src/components/common/flexBox/index.tsx
@@ -3,7 +3,7 @@ import { HTMLAttributes, ReactNode } from 'react'
 
 export interface FlexBoxProps extends HTMLAttributes<HTMLDivElement> {
   direction?: 'row' | 'column'
-  justify?: 'flex-start' | 'flex-end' | 'center' | 'space-between'
+  justify?: 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around'
   align?: 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch'
   gap?: number
   fullWidth?: boolean

--- a/src/components/common/flexBox/index.tsx
+++ b/src/components/common/flexBox/index.tsx
@@ -3,7 +3,7 @@ import { HTMLAttributes, ReactNode } from 'react'
 
 export interface FlexBoxProps extends HTMLAttributes<HTMLDivElement> {
   direction?: 'row' | 'column'
-  justify?: 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around'
+  justify?: 'flex-start' | 'flex-end' | 'center' | 'space-between'
   align?: 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch'
   gap?: number
   fullWidth?: boolean
@@ -29,7 +29,14 @@ export const FlexBox = ({
   ...props
 }: FlexBoxProps) => {
   return (
-    <StyledFlexBox direction={direction} justify={justify} align={align} gap={gap} fullWidth={fullWidth} {...props}>
+    <StyledFlexBox
+      direction={direction}
+      justify={justify}
+      align={align}
+      gap={gap}
+      fullWidth={fullWidth}
+      {...props}
+    >
       {children}
     </StyledFlexBox>
   )

--- a/src/components/common/postCard/index.tsx
+++ b/src/components/common/postCard/index.tsx
@@ -1,0 +1,93 @@
+import styled from '@emotion/styled'
+
+import { FlexBox } from '@/components/common/flexBox'
+import ListRow from '@/components/common/listRow'
+import { Text } from '@/components/common/Text'
+import { theme } from '@/styles/theme'
+
+interface PostCardProps {
+  likesNum: number
+  commentsNum: number
+  image?: string
+  title: string
+  content: string
+  author: string
+  createdAt: string
+}
+
+// useEffect(() => {
+//   console.log('받아온 정보를 이용하여 작성자 정보 알아오기')
+// }, [])
+
+const PostCard = ({
+  likesNum = 50,
+  commentsNum = 33,
+  image = 'https://loremflickr.com/100/100/dog',
+  title = '제목을 입력해주세요',
+  content = '내용을 입력합니다 내용내용',
+  author = '김유진',
+  createdAt = '2023.03.03',
+}: PostCardProps) => {
+  return (
+    <PostCardWrapper>
+      <ListRow
+        leftImage={
+          <img
+            src={'https://loremflickr.com/30/30/dog​​'}
+            alt={'profileImage'}
+          />
+        }
+        mainText={
+          <Text typo={'Caption_11'} color={'GRAY600'}>
+            {author}
+          </Text>
+        }
+        subElement={
+          <Text typo={'SubHead_14'} color={'BLACK'}>
+            {title}
+          </Text>
+        }
+        rightElement={
+          <Text typo={'Caption_11'} color={'GRAY500'}>
+            {createdAt}
+          </Text>
+        }
+      />
+      {image && <img src={image} />}
+      <FlexBox align={'center'} justify={'flex-start'} fullWidth={true}>
+        <Text typo={'Caption_11'} color={'GRAY600'}>
+          {content}
+        </Text>
+      </FlexBox>
+      <FlexBox
+        align={'center'}
+        justify={'flex-start'}
+        fullWidth={true}
+        gap={10}
+      >
+        <Text typo={'Body_12'} color={'GRAY500'}>
+          {` 좋아요 : ${likesNum}`}
+        </Text>
+        <Text typo={'Body_12'} color={'GRAY500'}>
+          {`댓글 :  ${commentsNum}`}
+        </Text>
+      </FlexBox>
+    </PostCardWrapper>
+  )
+}
+
+export default PostCard
+
+const PostCardWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 331px;
+  padding: 10px;
+  gap: 10px;
+  border-radius: 10px;
+  background-color: ${theme.palette.GRAY100};
+  align-items: center;
+  box-shadow:
+    0px 0px 2px 0px rgba(0, 0, 0, 0.25),
+    0px 4px 4px 0px rgba(0, 0, 0, 0.14);
+`


### PR DESCRIPTION
## 이슈번호
- close #7 
## 작업내용 설명
### props 설명
```ts
interface PostCardProps {
  likesNum: number
  commentsNum: number
  image?: string
  title: string
  content: string
  author: string
  createdAt: string
}
```
- likesNum : 추후 좋아요 개수를 넘겨받습니다.
- commentsNum : 댓글 개수를 받습니다.
- image : (optional) 이미지 링크를 string 형식으로 받습니다.
- title: 게시글의 제목을 받습니다.
- content : 게시글의 내용을 받습니다.
- author : 게시글의 작성자 이름을 받습니다.
- createdAt: 게시글의 생성 날짜를 받습니다.

이 모든 props는 `Post[]` 객체에서 map을 돌려 넘겨받는 것으로 설정할 예정입니다 :)

## 리뷰어에게 한마디
제가 API 명세를 보면서 해당 컴포넌트를 제작하였는데, Post의 명세가 아래와 같더라구요.
```
{
  "likes": Like[],
  "comments": Comment[],
  "_id": String,
  "image": Optional<String>,
  "imagePublicId": Optional<String>,
  "title": String,
  "channel": Channel,
  "author": User,
  "createdAt": String,
  "updatedAt": String
}
```
현재로써는 Post[] 객체를 통해서, 작성자의 이름만 알수 있지, `userId`를 알아낼 수 없어 프로필 이미지를 패칭해올 수 없습니다.
그래서 API 요청에 authorId를 추가해달라고 말씀하던가, 게시글 카드에 프로필 이미지를 보이게 하는 것을 포기해야 할 것 같습니다. ㅠㅠ 
