### PR TITLE
[Feature] 회원가입 및 로그인 인가 처리 및 react-query 전환

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,22 +4,31 @@ import Layout from '@/components/layouts/Layout'
 import ChattingRouter from '@/pages/chatting'
 import FriendsRouter from '@/pages/friends'
 import ChannelsRouter from '@/pages/home'
+import CreateChannel from '@/pages/home/CreateChannel'
 import LoginPage from '@/pages/login'
 import MyProfileRouter from '@/pages/myprofile'
 import PostRouter from '@/pages/postList'
+import PrivateRoute from '@/pages/redirect/PrivateRoute'
 import RegisterRouter from '@/pages/register'
 
 const App = () => {
   return (
     <Routes>
       <Route element={<Layout />}>
-        <Route path={'*'} element={<ChannelsRouter />} />
-        <Route path={'/posts'} element={<PostRouter />} />
-        <Route path={'/friends'} element={<FriendsRouter />}></Route>
-        <Route path={'/myprofile'} element={<MyProfileRouter />}></Route>
-        <Route path={'/chatting'} element={<ChattingRouter />}></Route>
-        <Route path={'/login/*'} element={<LoginPage />} />
-        <Route path={'/register/*'} element={<RegisterRouter />} />
+        <Route element={<PrivateRoute auth={true} />}>
+          <Route path={'*'} element={<ChannelsRouter />} />
+          <Route path={'/posts'} element={<PostRouter />} />
+          <Route path={'/friends'} element={<FriendsRouter />}></Route>
+          <Route path={'/myprofile'} element={<MyProfileRouter />}></Route>
+          <Route path={'/chatting'} element={<ChattingRouter />}></Route>
+        </Route>
+        <Route element={<PrivateRoute auth={false} />}>
+          <Route path={'/login/*'} element={<LoginPage />} />
+          <Route path={'/register/*'} element={<RegisterRouter />} />
+        </Route>
+        <Route element={<PrivateRoute auth={true} superAuth={true} />}>
+          <Route path={'/create'} element={<CreateChannel />} />
+        </Route>
       </Route>
     </Routes>
   )

--- a/src/hooks/useLoginMutation.tsx
+++ b/src/hooks/useLoginMutation.tsx
@@ -1,0 +1,5 @@
+const useLoginMutation = () => {
+  return <div>{'useLoginMutation'}</div>
+}
+
+export default useLoginMutation

--- a/src/hooks/useRegisterMutation.tsx
+++ b/src/hooks/useRegisterMutation.tsx
@@ -1,0 +1,5 @@
+const useRegisterMutation = () => {
+  return <div>{'useRegisterMutation'}</div>
+}
+
+export default useRegisterMutation

--- a/src/libs/apis/auth/authType.ts
+++ b/src/libs/apis/auth/authType.ts
@@ -19,3 +19,7 @@ export type User = {
   createdAt: string
   updatedAt: string
 }
+export type SignUpResponse = {
+  user: User
+  token: string
+}

--- a/src/libs/apis/axios.ts
+++ b/src/libs/apis/axios.ts
@@ -7,6 +7,44 @@ export const axiosAPI = axios.create({
   baseURL: import.meta.env.VITE_BASE_URL,
 })
 
+// // Add a request interceptor
+// axiosAPI.interceptors.request.use(
+//   function (config) {
+//     // 요청 바로 직전
+//     // axios 설정값에 대해 작성합니다.
+//     console.log(config)
+//     return config
+//   },
+//   function (error) {
+//     // 요청 에러 처리를 작성합니다.
+//     return Promise.reject(error)
+//   },
+// )
+
+// // Add a response interceptor
+// axiosAPI.interceptors.response.use(
+//   function (response) {
+//     /*
+//         http status가 200인 경우
+//         응답 바로 직전에 대해 작성합니다.
+//         .then() 으로 이어집니다.
+//     */
+//     return response
+//   },
+
+//   function (error) {
+//     /*
+//         http status가 200이 아닌 경우
+//         응답 에러 처리를 작성합니다.
+//         .catch() 으로 이어집니다.
+//     */
+//     if (error.response && error.response.status === 401) {
+//       return new Promise(() => {}) //이행되지 않은 Promise를 반환하여 Promise Chaining 끊어주기
+//     }
+//     return Promise.reject(error)
+//   },
+// )
+
 // Response interceptor
 // function interceptorResponseFulfilled(res: AxiosResponse) {
 //   if (200 <= res.status && res.status < 300) {

--- a/src/libs/apis/axios.ts
+++ b/src/libs/apis/axios.ts
@@ -8,18 +8,18 @@ export const axiosAPI = axios.create({
 })
 
 // Response interceptor
-function interceptorResponseFulfilled(res: AxiosResponse) {
-  if (200 <= res.status && res.status < 300) {
-    return res
-  }
+// function interceptorResponseFulfilled(res: AxiosResponse) {
+//   if (200 <= res.status && res.status < 300) {
+//     return res
+//   }
 
-  return Promise.reject(res)
-}
+//   return Promise.reject(res)
+// }
 
-function interceptorResponseRejected(error: AxiosError<ApiErrorScheme>) {
-  if (error.response?.data?.message) {
-    return Promise.reject(new ApiException(error.response.data, error.response.status))
-  }
-}
+// function interceptorResponseRejected(error: AxiosError<ApiErrorScheme>) {
+//   if (error.response?.data?.message) {
+//     return Promise.reject(new ApiException(error.response.data, error.response.status))
+//   }
+// }
 
-axiosAPI.interceptors.response.use(interceptorResponseFulfilled, interceptorResponseRejected)
+// axiosAPI.interceptors.response.use(interceptorResponseFulfilled, interceptorResponseRejected)

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -42,6 +42,11 @@ const Login = () => {
       localStorage.setItem('role', data.data.user.role)
       localStorage.setItem('isLogin', 'true')
       alert('로그인 성공')
+      if (localStorage.getItem('token')) {
+        axiosAPI.defaults.headers.common['Authorization'] = `Bearer ${localStorage.getItem(
+          'token',
+        )}`
+      }
       navigate('/')
     },
     onError: () => {

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -21,29 +21,30 @@ const Login = () => {
   const submitLogin = () => {
     if (emailInputRef.current && passwordInputRef.current) {
       setIsLoading(true)
-      loginMutation.mutate()
+      const body = {
+        email: emailInputRef.current.value,
+        password: passwordInputRef.current.value,
+      }
+      console.log(body)
+      loginMutation.mutate(body)
     }
   }
 
-  const loginPost = async () => {
-    const { data } = await axiosAPI.post('/login', {
-      email: emailInputRef.current?.value,
-      password: passwordInputRef.current?.value,
-    })
-    return data
+  const loginPost = async (body: object) => {
+    return await axiosAPI.post('/login', body)
   }
-  const loginMutation = useMutation(loginPost, {
+
+  const loginMutation = useMutation((body: object) => loginPost(body), {
     onSuccess: (data) => {
       console.log(data)
       setIsLoading(false)
-      localStorage.setItem('token', data.token)
-      localStorage.setItem('role', data.user.role)
+      localStorage.setItem('token', data.data.token)
+      localStorage.setItem('role', data.data.user.role)
       localStorage.setItem('isLogin', 'true')
       alert('로그인 성공')
       navigate('/')
     },
     onError: () => {
-      // if (err.message === 'Request failed with status code 400')
       setIsLoading(false)
       alert('아이디와 비밀번호를 확인해주세요!')
     },

--- a/src/pages/redirect/PrivateRoute.tsx
+++ b/src/pages/redirect/PrivateRoute.tsx
@@ -1,15 +1,16 @@
 import { Navigate, Outlet } from 'react-router-dom'
 type PrivateRouteProps = {
   auth: boolean
+  superAuth?: boolean
 }
 
-const PrivateRoute = ({ auth }: PrivateRouteProps) => {
-  const isLogined = localStorage.getItem('loginState')
+const PrivateRoute = ({ auth, superAuth }: PrivateRouteProps) => {
+  const isLogin = localStorage.getItem('isLogin')
 
   if (auth) {
-    return isLogined === null || isLogined == 'false' ? <Navigate to={'/login'} /> : <Outlet />
+    return isLogin === null || isLogin == 'false' ? <Navigate to={'/login'} /> : <Outlet />
   } else {
-    return isLogined === null || isLogined == 'false' ? <Outlet /> : <Navigate to={'/'} />
+    return isLogin === null || isLogin == 'false' ? <Outlet /> : <Navigate to={'/'} />
   }
 }
 

--- a/src/pages/redirect/Redirect.tsx
+++ b/src/pages/redirect/Redirect.tsx
@@ -2,7 +2,6 @@ import { Navigate } from 'react-router-dom'
 
 const RedirectPage = () => {
   //여기서 로그인 여부를 boolean으로 받아 확인
-  //   -> localStorage, jotai Store중 어디에 로그인 여부를 저장할지 고민
   const isLogin = localStorage.getItem('loginState')
 
   return <div>{!isLogin && <Navigate to={'/login'}></Navigate>}</div>

--- a/src/pages/register/Register.tsx
+++ b/src/pages/register/Register.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import { useMutation } from '@tanstack/react-query'
+import { AxiosResponse } from 'axios'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
@@ -9,6 +10,7 @@ import Input from '@/components/common/input'
 import Loading from '@/components/common/loading'
 import Spacing from '@/components/common/spacing'
 import { Text } from '@/components/common/text'
+import { SignUpResponse, User } from '@/libs/apis/auth/authType'
 import { axiosAPI } from '@/libs/apis/axios'
 import { theme } from '@/styles/theme'
 
@@ -20,9 +22,9 @@ const Register = () => {
   const [checkBox1, setCheckBox1] = useState(false)
   const [checkBox2, setCheckBox2] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
-  useEffect(() => {
-    console.log(checkBox1, checkBox2)
-  }, [checkBox1, checkBox2])
+
+  useEffect(() => {}, [checkBox1, checkBox2])
+
   const formValidation = () => {
     if (emailInputRef.current && emailInputRef.current.value == '') {
       alert('이메일을 입력하세요')
@@ -45,6 +47,7 @@ const Register = () => {
   }
 
   const submitRegister = async (e: React.FormEvent) => {
+    e.preventDefault()
     if (!formValidation()) {
       alert('입력이 올바르지 않습니다.')
       return
@@ -57,24 +60,24 @@ const Register = () => {
     setIsLoading(true)
     if (formValidation()) {
       if (emailInputRef.current && passwordInputRef.current && userNameInputRef.current) {
-        registerMutation.mutate()
+        const body = {
+          email: emailInputRef.current.value,
+          fullName: userNameInputRef.current.value,
+          password: passwordInputRef.current.value,
+        }
+        registerMutation.mutate(body)
       }
     }
   }
-  const registerPost = async () => {
-    const { data } = await axiosAPI.post('/signup', {
-      email: emailInputRef.current?.value,
-      fullName: userNameInputRef.current?.value,
-      password: passwordInputRef.current?.value,
-    })
-    return data
+  const registerPost = async (body: object): Promise<SignUpResponse | undefined> => {
+    return await axiosAPI.post('/signup', body)
   }
-  const registerMutation = useMutation(registerPost, {
+  const registerMutation = useMutation((body: object) => registerPost(body), {
     onSuccess: (data) => {
       console.log(data)
       setIsLoading(false)
       alert('회원가입 성공!')
-      // navigate('/login')
+      navigate('/login')
     },
     onError: () => {
       alert('회원가입 실패! 이미 있는 계정입니다.')

--- a/src/pages/register/Register.tsx
+++ b/src/pages/register/Register.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { useMutation } from '@tanstack/react-query'
-import { useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import BackgroundImage from '@/assets/images/Background-nofootPrint.svg'
@@ -20,7 +20,9 @@ const Register = () => {
   const [checkBox1, setCheckBox1] = useState(false)
   const [checkBox2, setCheckBox2] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
-
+  useEffect(() => {
+    console.log(checkBox1, checkBox2)
+  }, [checkBox1, checkBox2])
   const formValidation = () => {
     if (emailInputRef.current && emailInputRef.current.value == '') {
       alert('이메일을 입력하세요')
@@ -47,7 +49,8 @@ const Register = () => {
       alert('입력이 올바르지 않습니다.')
       return
     }
-    if (!(checkBox1 && checkBox2)) {
+
+    if (checkBox1 == false || checkBox2 == false) {
       alert('약관 동의에 체크해주세요.')
       return
     }
@@ -82,8 +85,12 @@ const Register = () => {
   const goLoginPage = () => {
     navigate('/login')
   }
-  const checkHandler = (index: number) => {
-    index == 1 ? setCheckBox1(!checkBox1) : setCheckBox2(!checkBox2)
+  const checkHandler1 = (checked: boolean) => {
+    checked ? setCheckBox1(true) : setCheckBox1(false)
+  }
+
+  const checkHandler2 = (checked: boolean) => {
+    checked ? setCheckBox2(true) : setCheckBox2(false)
   }
   return isLoading ? (
     <Loading />
@@ -107,8 +114,8 @@ const Register = () => {
           <StyleLabel>
             <StyledInput
               type={'checkbox'}
-              onChange={() => {
-                checkHandler(1)
+              onChange={(e) => {
+                checkHandler1(e.target.checked)
               }}
             ></StyledInput>
             <StyleText>{'서비스 이용약관 동의'}</StyleText>
@@ -118,8 +125,8 @@ const Register = () => {
           <StyleLabel>
             <StyledInput
               type={'checkbox'}
-              onChange={() => {
-                checkHandler(2)
+              onChange={(e) => {
+                checkHandler2(e.target.checked)
               }}
             ></StyledInput>
             <StyleText>{'개인정보 수집 및 활용 동의'}</StyleText>

--- a/src/pages/register/Register.tsx
+++ b/src/pages/register/Register.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled'
 import { useMutation } from '@tanstack/react-query'
-import { AxiosResponse } from 'axios'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import BackgroundImage from '@/assets/images/Background-nofootPrint.svg'
@@ -10,7 +9,7 @@ import Input from '@/components/common/input'
 import Loading from '@/components/common/loading'
 import Spacing from '@/components/common/spacing'
 import { Text } from '@/components/common/text'
-import { SignUpResponse, User } from '@/libs/apis/auth/authType'
+import { SignUpResponse } from '@/libs/apis/auth/authType'
 import { axiosAPI } from '@/libs/apis/axios'
 import { theme } from '@/styles/theme'
 


### PR DESCRIPTION
## 이슈번호

<!-- - close 뒤에 이슈 달아주기 -->

- close #55 

## 작업내용 설명

<!-- 스크린샷 및 작업내용을 적어주세요 -->
1. 회원가입 및 로그인 요청을 useMutation으로 관리하도록 하였습니다.
2. 로그인 한 사용자와 안 한 사용자를 구분하여 인가 처리 하였습니다. 이제 login 하지 않으면 자동으로 login 페이지로 강제 redirect 되도록 하였습니다.
3. 잘 보이진 않지만 회원가입 및 로그인 성공 전 로딩 중일 때 로딩 컴포넌트를 렌더링 하도록 하였습니다.

## 리뷰어에게 한마디

<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->
수정할 사항 + 추가할 사항 있으면 코멘트 남겨주세요!!😁 바로 수정하겠습니다!
