### PR TITLE
[Fix] : 게시글에 contents도 저장할 수 있도록 수정

### DIFF
--- a/src/libs/apis/post/postType.ts
+++ b/src/libs/apis/post/postType.ts
@@ -32,7 +32,10 @@ export type Comment = {
 }
 
 export type CreatePostRequest = {
-  title: string
+  title: {
+    title: string
+    body: string
+  }
   image: string | null
   channelId: string
 }

--- a/src/pages/postList/NewPost.tsx
+++ b/src/pages/postList/NewPost.tsx
@@ -10,13 +10,16 @@ import { FlexBox } from '@/components/common/flexBox'
 import { Text } from '@/components/common/text'
 import ImageUploader from '@/components/posts/ImageUploader'
 import PostApi from '@/libs/apis/post/postApi'
+import { Post } from '@/libs/apis/post/postType'
+import { queryClient } from '@/libs/apis/queryClient'
 import encodeFileToBase64 from '@/libs/utils/encodeFileToBase64'
 import { theme } from '@/styles/theme'
 
 const NewPostPage = () => {
   const postMutation = useMutation(PostApi.CREATE_POST, {
-    onSuccess: () => {
-      navigate(`/posts/${channelID}`)
+    onSuccess: (newPost: Post) => {
+      queryClient.setQueryData(['posts', newPost._id], newPost)
+      navigate(`/posts/${channelID}/${newPost._id}`)
     },
   })
   const navigate = useNavigate()
@@ -37,12 +40,29 @@ const NewPostPage = () => {
   }
 
   const handleCreatePost = () => {
-    if (title && curImage) {
-      postMutation.mutate({
-        title: title,
-        image: btoa(curImage),
-        channelId: channelID,
-      })
+    if (title && contents) {
+      if (contents.length > 0) {
+        postMutation.mutate({
+          title: {
+            title: title,
+            body: contents,
+          },
+          image: null,
+          channelId: channelID,
+        })
+      }
+      if (curImage && contents.length > 0) {
+        postMutation.mutate({
+          title: {
+            title: title,
+            body: contents,
+          },
+          image: btoa(curImage),
+          channelId: channelID,
+        })
+      }
+    } else {
+      alert('게시글 내용이 비었습니다!')
     }
   }
   return (

--- a/src/pages/postList/[postId].tsx
+++ b/src/pages/postList/[postId].tsx
@@ -1,0 +1,9 @@
+const PostDetailPage = () => {
+  return (
+    <>
+      <div>{'ㅁㄴㅇㄹ'}</div>
+    </>
+  )
+}
+
+export default PostDetailPage


### PR DESCRIPTION
## 작업내용 설명
현재 게시글은 post의 제목만 받을 수 있도록 되어 있는데, contents도 받을 수 있도록 수정해봤습니다.
```ts
export type CreatePostRequest = {
  title: {
    title: string
    body: string
  }
  image: string | null
  channelId: string
}
```
이렇게 request 형식을 바꿨네요! 