### PR TITLE
[Feat] 마이페이지 프로필 이미지 post 기능 추가

### DIFF
--- a/src/components/common/profileImage/index.tsx
+++ b/src/components/common/profileImage/index.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled'
-import { ComponentProps, useEffect, useState } from 'react'
+import { ComponentProps, RefObject, useEffect, useRef, useState } from 'react'
 
 import defaultImage from '@/assets/images/profile.png'
+import { axiosAPI } from '@/libs/apis/axios'
 
 interface ProfileImageProps extends ComponentProps<'div'> {
   size: number
   image: string
   updatable: boolean
-  //   updateImage?: Uint8Array
 }
 
 interface ImageProps {
@@ -22,17 +22,30 @@ const ProfileImage = ({
 }: ProfileImageProps) => {
   const [loadable, setLoadable] = useState(false)
   const [selectedImage, setSelectedImage] = useState(image)
+  const imgRef = useRef<HTMLInputElement>(null) as RefObject<HTMLInputElement>
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selectedFile = e.target.files![0]
-    if (selectedFile) {
-      const reader = new FileReader()
+  const handleImageChange = () => {
+    if (imgRef.current && imgRef.current?.files) {
+      if (imgRef.current.files[0].length === 0) return
 
-      reader.onload = (e) => {
-        const result = e.target?.result as string
-        setSelectedImage(result)
-      }
-      reader.readAsDataURL(selectedFile)
+      axiosAPI
+        .post(
+          '/users/upload-photo',
+          {
+            isCover: false,
+            image: imgRef.current?.files[0],
+          },
+          {
+            headers: {
+              Authorization: `bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7Il9pZCI6IjY1MDJhYTM3YWE0MDA0NWY1Y2ZmN2IyZiIsImVtYWlsIjoibmV3amVhbnMifSwiaWF0IjoxNjk0NzYxOTE2fQ.dIC03yB0pCLn3SUwu8kFd1UUaoqNuXEJ775oGb_116E`,
+              'Content-Type': 'multipart/form-data',
+            },
+          },
+        )
+        .then((response) => {
+          console.log(response)
+          setSelectedImage(response.data.image)
+        })
     }
   }
   useEffect(() => {
@@ -40,9 +53,7 @@ const ProfileImage = ({
       setLoadable(true)
     }
   }, [])
-  //   const mimeType = 'image/png'
-  //   const base64ImageData = btoa(String.fromCharCode(...updateImage))
-  //   const dataUrl = `data:${mimeType};base64,${base64ImageData}`
+
   return (
     <span {...props}>
       <label htmlFor={'fileInput'}>
@@ -51,10 +62,11 @@ const ProfileImage = ({
       {loadable ? (
         <input
           type={'file'}
+          ref={imgRef}
           id={'fileInput'}
           style={{ display: 'none' }}
           accept={'image/*'}
-          onChange={handleFileChange}
+          onChange={handleImageChange}
         />
       ) : null}
     </span>
@@ -65,6 +77,7 @@ const Image = styled.img<ImageProps>`
   width: ${(props) => props.size + 'px'};
   height: ${(props) => props.size + 'px'};
   border-radius: 50%;
+  object-fit: cover;
 `
 
 export default ProfileImage


### PR DESCRIPTION
## 이슈번호

<!-- - close 뒤에 이슈 달아주기 --> 

- close #54 

## 작업내용 설명

<!-- 스크린샷 및 작업내용을 적어주세요 -->

<img width="300" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_PETTALK_Yrnana/assets/96521594/37a70b54-c76f-40d4-a37e-9cdd3aa41a43">
<br/>
마이페이지에서 이미지 영역을 누르면 새로운 이미지를 업로드 함과 동시에 서버로 post하는 기능을 추가했습니다.

## 리뷰어에게 한마디
현재 post만 되는 상태로 새로고침 하면 useEffect로 서버에서 이미지를 불러와 보여주는 기능을 추가해야 합니다!
<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->
