### PR TITLE
[Style] textarea 컴포넌트 제작

### DIFF
--- a/src/components/common/textarea/index.tsx
+++ b/src/components/common/textarea/index.tsx
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled'
+import { ComponentProps, forwardRef } from 'react'
+
+import { FlexBox } from '@/components/common/flexBox'
+import { palette } from '@/styles/palette'
+
+interface TextAreaProps extends ComponentProps<'textarea'> {
+  width?: number
+  height?: number
+  placeholder?: string
+}
+
+const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(function Textarea(
+  { width, height, placeholder = '메세지를 입력해주세요.' }: TextAreaProps,
+  textareaRef,
+) {
+  return (
+    <FlexBox fullWidth={true}>
+      <StyledTextArea
+        widthProps={width}
+        heightProps={height}
+        ref={textareaRef}
+        placeholder={placeholder}
+      />
+    </FlexBox>
+  )
+})
+
+const StyledTextArea = styled.textarea<{ widthProps?: number; heightProps?: number }>`
+  width: ${({ widthProps }) => (widthProps ? `${widthProps}px` : '100%')};
+  height: ${({ heightProps }) => (heightProps ? `${heightProps}px` : '50px')};
+  background-color: ${palette.WHITE};
+  color: ${palette.GRAY700};
+  border-radius: 10px;
+  border: none;
+  resize: none;
+  padding: 15px;
+  padding-right: 40px;
+  line-height: 130%;
+  ${({ theme }) => theme.typo.Body_13};
+  ::placeholder {
+    ${({ theme }) => theme.typo.Caption_11}
+    color: ${({ theme }) => theme.palette.GRAY500};
+  }
+`
+
+export default TextArea


### PR DESCRIPTION
## 이슈번호

<!-- - close 뒤에 이슈 달아주기 -->

- close #75 

## 작업내용 설명
채팅창, 디테일 페이지에서 사용되는 textarea 컴포넌트를 제작했습니다!

![image](https://github.com/prgrms-fe-devcourse/FEDC4_PETTALK_Yrnana/assets/32586926/37f75cc5-6f6e-4f4c-8daf-2ed8b6c266cd)

![image](https://github.com/prgrms-fe-devcourse/FEDC4_PETTALK_Yrnana/assets/32586926/a490e8a9-8c67-4493-bf2d-f7bc3342ee38)


### props 설명

```tsx
interface TextAreaProps extends ComponentProps<'textarea'> {
  width?: number
  height?: number
  placeholder?: string
}
```
`width` : 너비값 지정 / 기본 값 : 100%
`height` : 높이 지정 / 기본 값 : 50px
`placeholder`: placeholder 값 지정 / 기본 값: '메세지를 입력해주세요.'


### 예시
```tsx
 <TextArea />

 <TextArea width={200} height={200}/>

 <TextArea placeholder={'유리팀 화이팅'} />
```
## 리뷰어에게 한마디

* 처음에 input 컴포넌트처럼 svg delete 아이콘을 넣어봤는데 textarea에 내용을 길게 타이핑하고 보니 별로 이쁜 것 같지 않아서 피그마에서 디자인했던 그대로 svg 아이콘은 빼고 작업했습니다. 이 부분은 다시 상의 해보고 넣을지 말지 정한 후 리팩토링하도록 하겠습니다!
* @JeongWuk 님이 제작하시는 detail view 페이지의 댓글 코멘트 창에도 활용하시면 좋을 것 같습니다!
