### PR TITLE
[Refac] : 채팅 목록 페이지 실시간 반영 및 레이아웃 리팩토링

### DIFF
--- a/src/libs/apis/message/messageApi.ts
+++ b/src/libs/apis/message/messageApi.ts
@@ -34,7 +34,6 @@ const MessageApi = {
   READ_MESSAGE: async (sender: string): Promise<Message> => {
     axiosAPI.defaults.headers.common['Authorization'] = `Bearer ${localStorage.getItem('token')}`
     const response = await axiosAPI.put('/messages/update-seen', { sender })
-    console.log(response)
     return response.data
   },
 }

--- a/src/libs/apis/message/messageApi.ts
+++ b/src/libs/apis/message/messageApi.ts
@@ -33,7 +33,8 @@ const MessageApi = {
   },
   READ_MESSAGE: async (sender: string): Promise<Message> => {
     axiosAPI.defaults.headers.common['Authorization'] = `Bearer ${localStorage.getItem('token')}`
-    const response = await axiosAPI.put('/messages/update-seen', sender)
+    const response = await axiosAPI.put('/messages/update-seen', { sender })
+    console.log(response)
     return response.data
   },
 }

--- a/src/libs/apis/message/messageApi.ts
+++ b/src/libs/apis/message/messageApi.ts
@@ -28,7 +28,6 @@ const MessageApi = {
   SEND_MESSAGE: async (payload: MessageType): Promise<Message> => {
     axiosAPI.defaults.headers.common['Authorization'] = `Bearer ${localStorage.getItem('token')}`
     const response = await axiosAPI.post('/messages/create', payload)
-    console.log(response)
     return response.data
   },
   READ_MESSAGE: async (sender: string): Promise<Message> => {

--- a/src/pages/chatting/Chatting.tsx
+++ b/src/pages/chatting/Chatting.tsx
@@ -13,8 +13,10 @@ import Loading from '@/components/common/loading'
 import Spacing from '@/components/common/spacing'
 import TextArea from '@/components/common/textarea'
 import { User } from '@/libs/apis/auth/authType'
+import { Conversation } from '@/libs/apis/message/conversationType'
 import MessageApi from '@/libs/apis/message/messageApi'
 import { Message } from '@/libs/apis/message/messageType'
+import { queryClient } from '@/libs/apis/queryClient'
 import { userAtom } from '@/libs/store/userAtom'
 import { theme } from '@/styles/theme'
 
@@ -54,7 +56,20 @@ const Chatting = () => {
   })
 
   const mutation = useMutation(MessageApi.SEND_MESSAGE, {
-    onSuccess: () => {
+    onSuccess: (data) => {
+      console.log(data)
+      queryClient.invalidateQueries(['chattingList'])
+
+      const currentChattingList = queryClient.getQueryData<Conversation[]>(['chattingList'])
+      const updatedChattingList = currentChattingList?.map((chat) => {
+        if (chat._id[1] === opponent) {
+          return { ...chat, message: data.message }
+        }
+        return chat
+      })
+
+      queryClient.setQueryData(['chattingList'], updatedChattingList)
+
       if (messageRef.current) messageRef.current.value = ''
     },
     onError: (error) => {

--- a/src/pages/chattingList/ChattingList.tsx
+++ b/src/pages/chattingList/ChattingList.tsx
@@ -1,44 +1,34 @@
 import styled from '@emotion/styled'
 import { useQuery } from '@tanstack/react-query'
-// import { useQuery } from '@tanstack/react-query'
 import { useAtomValue } from 'jotai'
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import Search from '@/assets/icons/Search'
 import defaultProfileImage from '@/assets/images/defaultProfileImage.png'
-import AppBar from '@/components/common/appBar'
 import { FlexBox } from '@/components/common/flexBox'
 import Input from '@/components/common/input'
 import ListRow from '@/components/common/listRow'
 import Loading from '@/components/common/loading'
 import Spacing from '@/components/common/spacing'
-import { User } from '@/libs/apis/auth/authType'
-import { axiosAPI } from '@/libs/apis/axios'
+import { Conversation } from '@/libs/apis/message/conversationType'
+import MessageApi from '@/libs/apis/message/messageApi'
 import { userAtom } from '@/libs/store/userAtom'
 import { palette } from '@/styles/palette'
-import { typo } from '@/styles/typo'
 
-interface Conversation {
-  _id: string
-  message: string
-  sender: User
-  receiver: User
-  seen: boolean
-  createdAt: string
-}
 const ChattingList = () => {
   const userData = useAtomValue(userAtom)
   const [chattingList, setChattingList] = useState<Conversation[]>([])
   const [filteredChattingList, setFilteredChattingList] = useState<Conversation[]>([])
-  const [searchMode, setSearchMode] = useState(false)
+  const [searchMode, setSearchMode] = useState<boolean>(false)
   const navigate = useNavigate()
   const searchInputRef = useRef<HTMLInputElement | null>(null)
   const getChattingList = async () => {
-    return await axiosAPI.get('/messages/conversations')
+    return await MessageApi.GET_MESSAGES()
   }
-  const { data, isLoading } = useQuery(['chattingList'], getChattingList)
+  const { data, isLoading } = useQuery(['chattingList'], () => getChattingList())
 
+  console.log(data)
   const moveChattingRoom = async (selectedChat: Conversation) => {
     navigate(`/chatting`, {
       state: {
@@ -46,40 +36,42 @@ const ChattingList = () => {
         receiver: selectedChat.receiver,
       },
     })
-    await axiosAPI
-      .put('/messages/update-seen', {
-        sender: selectedChat.sender._id,
-      })
-      .then((response) => {
-        console.log(response)
-      })
-      .catch((err) => console.log(err))
+
+    // await axiosAPI
+    //   .put('/messages/update-seen', {
+    //     sender: selectedChat.sender._id,
+    //   })
+    //   .then((response) => {
+    //     console.log(response)
+    //   })
+    //   .catch((err) => console.log(err))
+
+    await MessageApi.READ_MESSAGE(selectedChat.sender._id)
   }
   const searchChattingList = () => {
     if (searchInputRef.current !== null) {
       setSearchMode(true)
+      const inputValue = searchInputRef.current!.value
       setFilteredChattingList(
         chattingList.filter(
-          (v) =>
-            v.sender.fullName.includes(searchInputRef.current.value) ||
-            v.message.includes(searchInputRef.current.value),
+          (chat) => chat.sender.fullName.includes(inputValue) || chat.message.includes(inputValue),
         ),
       )
     }
   }
+
   useEffect(() => {
-    if (data !== undefined) setChattingList(data?.data)
+    if (data !== undefined) setChattingList(data)
   }, [searchInputRef, filteredChattingList, chattingList])
+
   return (
-    <StyleWrapper>
+    <StyleWrapper justify={'flex-start'} direction={'column'} gap={20}>
       {isLoading ? (
         <Loading />
       ) : (
         <StyleChattingListWrapper>
-          <AppBar mainPage={false} />
-          <Spacing size={20} />
           <FlexBox direction={'row'} gap={20} fullWidth={true}>
-            <StyleSearchArea>
+            <StyleSearchArea align={'center'} fullWidth={true}>
               <Input placeholder={'대화 목록을 검색해보세요!'} ref={searchInputRef} />
               <StyleSearchIcon onClick={searchChattingList}>
                 <Search />
@@ -90,53 +82,59 @@ const ChattingList = () => {
           <StyleChattingItem>
             {filteredChattingList && searchMode ? (
               filteredChattingList.length !== 0 ? (
-                filteredChattingList.map((v) => (
+                filteredChattingList.map((chat) => (
                   <StyleListRow
-                    key={v._id}
+                    direction={'column'}
+                    fullWidth={true}
+                    gap={10}
+                    key={chat._id[1]}
                     onClick={() => {
-                      moveChattingRoom(v)
+                      moveChattingRoom(chat)
                     }}
                   >
                     <ListRow
-                      rightElement={<div style={{ color: 'red' }}>{v.seen ? '' : 'new'}</div>}
-                      leftImage={v.sender.image ? v.sender.image : defaultProfileImage}
-                      mainText={v.sender.fullName}
-                      subElement={v.message}
+                      rightElement={<div style={{ color: 'red' }}>{chat.seen ? '' : 'new'}</div>}
+                      leftImage={chat.sender.image ? chat.sender.image : defaultProfileImage}
+                      mainText={chat.sender.fullName}
+                      subElement={chat.message}
                       gap={10}
                       imageGap={10}
                       textColor={'GRAY600'}
                       textTypo={'Body_13'}
                     />
+                    <Stylehr />
                   </StyleListRow>
                 ))
               ) : (
                 <StyleNoData>{'검색 결과가 존재하지 않습니다!'}</StyleNoData>
               )
-            ) : data?.data.length !== 0 ? (
-              data?.data.map((v: Conversation) => (
+            ) : data?.length !== 0 ? (
+              data?.map((chat: Conversation) => (
                 <StyleListRow
-                  key={v._id}
+                  direction={'column'}
+                  fullWidth={true}
+                  gap={10}
+                  key={chat._id[1]}
                   onClick={() => {
-                    moveChattingRoom(v)
+                    moveChattingRoom(chat)
                   }}
                 >
                   <ListRow
-                    rightElement={<div style={{ color: 'red' }}>{v.seen ? '' : 'new'}</div>}
-                    leftImage={v.sender.image ? v.sender.image : defaultProfileImage}
-                    mainText={v.sender.fullName}
-                    subElement={v.message}
+                    rightElement={<div style={{ color: 'red' }}>{chat.seen ? '' : 'new'}</div>}
+                    leftImage={chat.sender.image ? chat.sender.image : defaultProfileImage}
+                    mainText={chat.sender.fullName}
+                    subElement={chat.message}
                     gap={10}
                     imageGap={10}
                     textColor={'GRAY600'}
                     textTypo={'Body_13'}
                   />
+                  <Stylehr />
                 </StyleListRow>
               ))
             ) : (
               <StyleNoData>{'아직 대화내역이 없습니다!'}</StyleNoData>
             )}
-
-            <hr style={{ borderStyle: 'solid', borderColor: `${palette.GRAY300}` }} />
           </StyleChattingItem>
         </StyleChattingListWrapper>
       )}
@@ -144,18 +142,17 @@ const ChattingList = () => {
   )
 }
 const StyleChattingListWrapper = styled.div`
-  .scroll::-webkit-scrollbar {
-    display: none;
-  }
-`
-const StyleListRow = styled.div`
-  cursor: pointer;
-  margin: 13px 0px;
-`
-const StyleSearchArea = styled.div`
-  display: flex;
   width: 100%;
-  align-items: center;
+`
+const StyleListRow = styled(FlexBox)`
+  cursor: pointer;
+  margin: 10px 0px;
+`
+const Stylehr = styled.hr`
+  border: 1px solid ${palette.GRAY300};
+  width: 100%;
+`
+const StyleSearchArea = styled(FlexBox)`
   text-align: center;
   padding: 0px 20px;
 `
@@ -169,14 +166,11 @@ const StyleChattingItem = styled.li`
 const StyleNoData = styled.div`
   text-align: center;
   margin: 30px;
-  font-size: ${typo.Body_16};
-  color: ${palette.GRAY600};
+  ${({ theme }) => theme.typo.Body_16};
+  color: ${palette.GRAY500};
 `
-const StyleWrapper = styled.div`
-  flex-direction: column;
+const StyleWrapper = styled(FlexBox)`
   height: 100%;
-  align-items: center;
-  gap: 20px;
 `
 
 export default ChattingList

--- a/src/pages/chattingList/ChattingList.tsx
+++ b/src/pages/chattingList/ChattingList.tsx
@@ -29,6 +29,7 @@ const ChattingList = () => {
   }
   const { data, isLoading } = useQuery(['chattingList'], () => getChattingList())
 
+  console.log(data)
   const moveChattingRoom = async (selectedChat: Conversation) => {
     navigate(`/chatting`, {
       state: {
@@ -37,16 +38,7 @@ const ChattingList = () => {
       },
     })
 
-    await axiosAPI
-      .put('/messages/update-seen', {
-        sender: selectedChat.sender._id,
-      })
-      .then((response) => {
-        console.log(response)
-      })
-      .catch((err) => console.log(err))
-
-    // await MessageApi.READ_MESSAGE(selectedChat.sender._id)
+    await MessageApi.READ_MESSAGE(selectedChat.sender._id)
   }
   const searchChattingList = () => {
     if (searchInputRef.current !== null) {

--- a/src/pages/chattingList/ChattingList.tsx
+++ b/src/pages/chattingList/ChattingList.tsx
@@ -11,7 +11,6 @@ import Input from '@/components/common/input'
 import ListRow from '@/components/common/listRow'
 import Loading from '@/components/common/loading'
 import Spacing from '@/components/common/spacing'
-import { axiosAPI } from '@/libs/apis/axios'
 import { Conversation } from '@/libs/apis/message/conversationType'
 import MessageApi from '@/libs/apis/message/messageApi'
 import { userAtom } from '@/libs/store/userAtom'
@@ -29,7 +28,6 @@ const ChattingList = () => {
   }
   const { data, isLoading } = useQuery(['chattingList'], () => getChattingList())
 
-  console.log(data)
   const moveChattingRoom = async (selectedChat: Conversation) => {
     navigate(`/chatting`, {
       state: {
@@ -96,7 +94,11 @@ const ChattingList = () => {
                     }}
                   >
                     <ListRow
-                      rightElement={<div style={{ color: 'red' }}>{chat.seen ? '' : 'new'}</div>}
+                      rightElement={
+                        <div style={{ color: 'red' }}>
+                          {!chat.seen && chat.receiver._id === userData._id ? 'new' : ''}
+                        </div>
+                      }
                       leftImage={
                         findOpponent(chat).image ? findOpponent(chat).image : defaultProfileImage
                       }
@@ -125,7 +127,11 @@ const ChattingList = () => {
                   }}
                 >
                   <ListRow
-                    rightElement={<div style={{ color: 'red' }}>{chat.seen ? '' : 'new'}</div>}
+                    rightElement={
+                      <div style={{ color: 'red' }}>
+                        {!chat.seen && chat.receiver._id === userData._id ? 'new' : ''}
+                      </div>
+                    }
                     leftImage={
                       findOpponent(chat).image ? findOpponent(chat).image : defaultProfileImage
                     }

--- a/src/pages/chattingList/ChattingList.tsx
+++ b/src/pages/chattingList/ChattingList.tsx
@@ -26,7 +26,15 @@ const ChattingList = () => {
   const getChattingList = async () => {
     return await MessageApi.GET_MESSAGES()
   }
-  const { data, isLoading } = useQuery(['chattingList'], () => getChattingList())
+  const { data, isLoading } = useQuery(['chattingList'], () => getChattingList(), {
+    refetchInterval: 2000,
+    refetchIntervalInBackground: true,
+    retry: 3,
+    onSuccess: async (responseData: Conversation[]) => {
+      await MessageApi.READ_MESSAGE(responseData[responseData.length - 1].sender._id)
+    },
+    cacheTime: 0,
+  })
 
   const moveChattingRoom = async (selectedChat: Conversation) => {
     navigate(`/chatting`, {

--- a/src/pages/chattingList/ChattingList.tsx
+++ b/src/pages/chattingList/ChattingList.tsx
@@ -41,11 +41,11 @@ const ChattingList = () => {
   const searchChattingList = () => {
     if (searchInputRef.current !== null) {
       const inputValue = searchInputRef.current.value
-      const sourceList = data?.length !== 0 ? data : chattingList // Use data if available, else use chattingList
+      const sourceList = data?.length !== 0 ? data : chattingList
       const filteredList = sourceList!.filter(
         (chat) => chat.sender.fullName.includes(inputValue) || chat.message.includes(inputValue),
       )
-      console.log('Filtered list:', filteredList)
+
       setFilteredChattingList(filteredList)
       setSearchMode(true)
     }
@@ -59,7 +59,7 @@ const ChattingList = () => {
   useEffect(() => {
     if (data !== undefined) {
       setChattingList(data)
-      setFilteredChattingList(data) // Update filteredChattingList initially with data
+      setFilteredChattingList(data)
     }
   }, [data])
 
@@ -81,42 +81,12 @@ const ChattingList = () => {
           </FlexBox>
           <Spacing size={30} />
           <StyleChattingItem>
-            {filteredChattingList && searchMode ? (
-              filteredChattingList.length !== 0 ? (
-                filteredChattingList.map((chat) => (
-                  <StyleListRow
-                    direction={'column'}
-                    fullWidth={true}
-                    gap={10}
-                    key={chat._id[1]}
-                    onClick={() => {
-                      moveChattingRoom(chat)
-                    }}
-                  >
-                    <ListRow
-                      rightElement={
-                        <div style={{ color: 'red' }}>
-                          {!chat.seen && chat.receiver._id === userData._id ? 'new' : ''}
-                        </div>
-                      }
-                      leftImage={
-                        findOpponent(chat).image ? findOpponent(chat).image : defaultProfileImage
-                      }
-                      mainText={findOpponent(chat).fullName}
-                      subElement={chat.message}
-                      gap={10}
-                      imageGap={10}
-                      textColor={'GRAY600'}
-                      textTypo={'Body_13'}
-                    />
-                    <Stylehr />
-                  </StyleListRow>
-                ))
-              ) : (
-                <StyleNoData>{'검색 결과가 존재하지 않습니다!'}</StyleNoData>
-              )
-            ) : data?.length !== 0 ? (
-              data?.map((chat: Conversation) => (
+            {(
+              filteredChattingList && searchMode
+                ? filteredChattingList.length !== 0
+                : data?.length !== 0
+            ) ? (
+              (filteredChattingList || data).map((chat) => (
                 <StyleListRow
                   direction={'column'}
                   fullWidth={true}
@@ -146,7 +116,7 @@ const ChattingList = () => {
                 </StyleListRow>
               ))
             ) : (
-              <StyleNoData>{'아직 대화내역이 없습니다!'}</StyleNoData>
+              <StyleNoData>{'검색 결과가 존재하지 않습니다!'}</StyleNoData>
             )}
           </StyleChattingItem>
         </StyleChattingListWrapper>

--- a/src/pages/chattingList/index.tsx
+++ b/src/pages/chattingList/index.tsx
@@ -1,11 +1,19 @@
 import { Route, Routes } from 'react-router-dom'
 
+import AppBarNavTemplate from '@/components/layouts/AppBarNavTemplate'
 import ChattingList from '@/pages/chattingList/ChattingList'
 
 const ChattingListRouter = () => {
   return (
     <Routes>
-      <Route path={'/'} element={<ChattingList />}></Route>
+      <Route
+        path={'/'}
+        element={
+          <AppBarNavTemplate hasNav={true}>
+            <ChattingList />
+          </AppBarNavTemplate>
+        }
+      />
     </Routes>
   )
 }


### PR DESCRIPTION
## 이슈번호

- close #94 

## 작업내용 설명

채팅 목록 페이지를 리팩토링 했습니다.

* 전체 레이아웃 수정 
* polling 적용으로 실시간 반영
* 프로필 상대방으로 고정
* 읽음 처리 개선 (상대방


https://github.com/prgrms-fe-devcourse/FEDC4_PETTALK_Yrnana/assets/32586926/73d767a5-4fcc-4770-9355-f5b16bca4a24



## 리뷰어에게 한마디

실시간으로 처리해야 하는 작업이 많다보니 polling 투성이라 조금 걱정되네요 ㅠㅠ 더 나은 방법이 있을지 고민해봐야할 것 같슴다...

<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->
