### PR TITLE
[Refac] 채팅창 페이지 코드 리팩토링

### DIFF
--- a/src/components/chatting/messageArea/index.tsx
+++ b/src/components/chatting/messageArea/index.tsx
@@ -1,0 +1,71 @@
+import { useAtomValue } from 'jotai'
+
+import Datetime from '@/components/chatting/datetime'
+import ChattingBubble from '@/components/common/chattingBubble'
+import { FlexBox } from '@/components/common/flexBox'
+import ListRow from '@/components/common/listRow'
+import Spacing from '@/components/common/spacing'
+import { Message } from '@/libs/apis/message/messageType'
+import { userAtom } from '@/libs/store/userAtom'
+
+interface FormattedMessage extends Message {
+  formattedDate: string
+  formattedTime: string
+}
+
+type MessageAreaProps = {
+  data: Message[]
+}
+
+const MessageArea = ({ data }: MessageAreaProps) => {
+  const userData = useAtomValue(userAtom)
+
+  const parsedMessages: FormattedMessage[] = data
+    ? data.map((message) => {
+        const parsedDate = new Date(message.createdAt)
+        const formattedDate = `${parsedDate.getFullYear()}년 ${
+          parsedDate.getMonth() + 1
+        }월 ${parsedDate.getDate()}일`
+        const formattedTime = `${String(parsedDate.getHours()).padStart(2, '0')}:${String(
+          parsedDate.getMinutes(),
+        ).padStart(2, '0')}`
+
+        return { ...message, formattedDate, formattedTime }
+      })
+    : []
+
+  const groupedMessages: Record<string, FormattedMessage[]> = {}
+  parsedMessages.forEach((message: FormattedMessage) => {
+    const date = message.formattedDate
+    if (!groupedMessages[date]) groupedMessages[date] = []
+    groupedMessages[date].push(message)
+  })
+  const entries = Object.entries(groupedMessages)
+
+  return entries.map(([date, messages]) => (
+    <FlexBox direction={'column'} gap={20} key={date}>
+      <Datetime content={date}></Datetime>
+      {messages.map((message) =>
+        userData._id === message.sender._id ? (
+          <ChattingBubble
+            key={message._id}
+            isMyChat={true}
+            message={message.message}
+            time={message.formattedTime}
+          />
+        ) : (
+          <ListRow
+            key={message._id}
+            leftImage={message.sender.image}
+            mainText={message.sender.fullName}
+            subElement={<ChattingBubble message={message.message} time={message.formattedTime} />}
+            rightElement={null}
+          />
+        ),
+      )}
+      <Spacing size={20}></Spacing>
+    </FlexBox>
+  ))
+}
+
+export default MessageArea

--- a/src/components/chatting/messageArea/index.tsx
+++ b/src/components/chatting/messageArea/index.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled'
 import { useAtomValue } from 'jotai'
 
 import Datetime from '@/components/chatting/datetime'
@@ -43,29 +44,38 @@ const MessageArea = ({ data }: MessageAreaProps) => {
   const entries = Object.entries(groupedMessages)
 
   return entries.map(([date, messages]) => (
-    <FlexBox direction={'column'} gap={20} key={date}>
+    <FlexBox direction={'column'} gap={20} key={date} fullWidth={true}>
       <Datetime content={date}></Datetime>
       {messages.map((message) =>
         userData._id === message.sender._id ? (
-          <ChattingBubble
-            key={message._id}
-            isMyChat={true}
-            message={message.message}
-            time={message.formattedTime}
-          />
+          <StyledWrapper key={message._id} isMyChat={true}>
+            <ChattingBubble
+              isMyChat={true}
+              message={message.message}
+              time={message.formattedTime}
+            />
+          </StyledWrapper>
         ) : (
-          <ListRow
-            key={message._id}
-            leftImage={message.sender.image}
-            mainText={message.sender.fullName}
-            subElement={<ChattingBubble message={message.message} time={message.formattedTime} />}
-            rightElement={null}
-          />
+          <StyledWrapper key={message._id} isMyChat={false}>
+            <ListRow
+              fullWidth={true}
+              leftImage={message.sender.image}
+              mainText={message.sender.fullName}
+              subElement={<ChattingBubble message={message.message} time={message.formattedTime} />}
+              rightElement={null}
+            />
+          </StyledWrapper>
         ),
       )}
       <Spacing size={20}></Spacing>
     </FlexBox>
   ))
 }
+
+const StyledWrapper = styled.div<{ isMyChat: boolean }>`
+  width: 100%;
+  padding-left: ${(props) => props.isMyChat && '20%'};
+  padding-right: ${(props) => !props.isMyChat && '20%'};
+`
 
 export default MessageArea

--- a/src/components/common/chattingBubble/index.tsx
+++ b/src/components/common/chattingBubble/index.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import { ComponentProps } from 'react'
 
+import { FlexBox } from '@/components/common/flexBox'
 import { Text } from '@/components/common/text'
 import { palette } from '@/styles/palette'
 import { type KeyOfPalette, type KeyOfTypo } from '@/styles/theme'
@@ -37,7 +38,13 @@ const ChattingBubble = ({
   ...props
 }: ChattingBubbleProps) => {
   return (
-    <BubbleContainer isMyChat={isMyChat} {...props}>
+    <BubbleContainer
+      justify={'flex-start'}
+      gap={10}
+      fullWidth={true}
+      isMyChat={isMyChat}
+      {...props}
+    >
       <StyledText isMyChat={isMyChat}>
         <MessageText typo={messageTypo} color={messageColor} {...props}>
           {message}
@@ -50,12 +57,8 @@ const ChattingBubble = ({
   )
 }
 
-const BubbleContainer = styled.div<{ isMyChat: boolean }>`
-  display: flex;
-  align-items: center;
+const BubbleContainer = styled(FlexBox)<{ isMyChat: boolean }>`
   justify-content: ${(props) => props.isMyChat && 'flex-end'};
-  gap: 10px;
-  width: 100%;
 `
 
 const StyledText = styled.div<{

--- a/src/libs/apis/message/messageApi.ts
+++ b/src/libs/apis/message/messageApi.ts
@@ -11,12 +11,10 @@ type MessageType = {
 
 const MessageApi = {
   GET_MESSAGES: async (): Promise<Conversation[]> => {
-    axiosAPI.defaults.headers.common['Authorization'] = `Bearer ${localStorage.getItem('token')}`
     const response = await axiosAPI.get('/messages/conversations')
     return response.data
   },
   GET_DETAIL_MESSAGES: async (userId: string): Promise<Message[]> => {
-    axiosAPI.defaults.headers.common['Authorization'] = `Bearer ${localStorage.getItem('token')}`
     const config: AxiosRequestConfig = {
       params: {
         userId: userId,
@@ -26,12 +24,10 @@ const MessageApi = {
     return response.data
   },
   SEND_MESSAGE: async (payload: MessageType): Promise<Message> => {
-    axiosAPI.defaults.headers.common['Authorization'] = `Bearer ${localStorage.getItem('token')}`
     const response = await axiosAPI.post('/messages/create', payload)
     return response.data
   },
   READ_MESSAGE: async (sender: string): Promise<Message> => {
-    axiosAPI.defaults.headers.common['Authorization'] = `Bearer ${localStorage.getItem('token')}`
     const response = await axiosAPI.put('/messages/update-seen', { sender })
     return response.data
   },

--- a/src/pages/chatting/Chatting.tsx
+++ b/src/pages/chatting/Chatting.tsx
@@ -4,24 +4,16 @@ import { useAtomValue } from 'jotai'
 import { MouseEvent, useEffect, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
-import Datetime from '@/components/chatting/datetime'
+import MessageArea from '@/components/chatting/messageArea'
 import Button from '@/components/common/button'
-import ChattingBubble from '@/components/common/chattingBubble'
 import { FlexBox } from '@/components/common/flexBox'
-import ListRow from '@/components/common/listRow'
 import Loading from '@/components/common/loading'
-import Spacing from '@/components/common/spacing'
 import TextArea from '@/components/common/textarea'
 import { User } from '@/libs/apis/auth/authType'
 import MessageApi from '@/libs/apis/message/messageApi'
 import { Message } from '@/libs/apis/message/messageType'
 import { userAtom } from '@/libs/store/userAtom'
 import { theme } from '@/styles/theme'
-
-interface FormattedMessage extends Message {
-  formattedDate: string
-  formattedTime: string
-}
 
 const Chatting = () => {
   const userData = useAtomValue(userAtom)
@@ -50,7 +42,11 @@ const Chatting = () => {
     retry: 3,
     onSuccess: async (responseData: Message[]) => {
       setMessageData(responseData)
-      await MessageApi.READ_MESSAGE(responseData[responseData.length - 1].sender._id)
+
+      if (responseData.length > 0) {
+        const senderUser = responseData[responseData.length - 1]!.sender as User
+        await MessageApi.READ_MESSAGE(senderUser._id)
+      }
     },
   })
 
@@ -77,28 +73,6 @@ const Chatting = () => {
     }
   }
 
-  const parsedMessages: FormattedMessage[] = data
-    ? data.map((message) => {
-        const parsedDate = new Date(message.createdAt)
-        const formattedDate = `${parsedDate.getFullYear()}년 ${
-          parsedDate.getMonth() + 1
-        }월 ${parsedDate.getDate()}일`
-        const formattedTime = `${String(parsedDate.getHours()).padStart(2, '0')}:${String(
-          parsedDate.getMinutes(),
-        ).padStart(2, '0')}`
-
-        return { ...message, formattedDate, formattedTime }
-      })
-    : []
-
-  const groupedMessages: Record<string, FormattedMessage[]> = {}
-  parsedMessages.forEach((message: FormattedMessage) => {
-    const date = message.formattedDate
-    if (!groupedMessages[date]) groupedMessages[date] = []
-    groupedMessages[date].push(message)
-  })
-  const entries = Object.entries(groupedMessages)
-
   useEffect(() => {
     setOpponent(sender._id === userData._id ? receiver._id : sender._id)
   }, [userData])
@@ -114,37 +88,7 @@ const Chatting = () => {
   return (
     <ChattingWrapper direction={'column'} fullWidth={true} align={'stretch'}>
       <MessageWrapper ref={messageWrapperRef}>
-        {isLoading ? (
-          <Loading></Loading>
-        ) : (
-          data &&
-          entries.map(([date, messages]) => (
-            <FlexBox direction={'column'} gap={20} key={date}>
-              <Datetime content={date}></Datetime>
-              {messages.map((message) =>
-                userData._id === message.sender._id ? (
-                  <ChattingBubble
-                    key={message._id}
-                    isMyChat={true}
-                    message={message.message}
-                    time={message.formattedTime}
-                  />
-                ) : (
-                  <ListRow
-                    key={message._id}
-                    leftImage={message.sender.image}
-                    mainText={message.sender.fullName}
-                    subElement={
-                      <ChattingBubble message={message.message} time={message.formattedTime} />
-                    }
-                    rightElement={null}
-                  />
-                ),
-              )}
-              <Spacing size={20}></Spacing>
-            </FlexBox>
-          ))
-        )}
+        {isLoading ? <Loading></Loading> : data && <MessageArea data={data} />}
       </MessageWrapper>
       <TypingFlexBox gap={10}>
         <TextArea ref={messageRef} height={20} />


### PR DESCRIPTION
## 이슈번호

- close #121 

## 작업내용 설명

기존 채팅창 페이지 코드를 리팩토링 했습니다.

* 필요없는 코드 삭제 (api 요청 시 불필요한 헤더 부분을 삭제했습니다.)
* 채팅 내역 패딩 추가 (기존 채팅창에서 채팅 내역이 길 때 width의 100%를 차지하고 있던 부분에 패딩을 조금 추가해서 여백을 넣었습니다.)

![image](https://github.com/prgrms-fe-devcourse/FEDC4_PETTALK_Yrnana/assets/32586926/e4142193-4bc8-4f11-8e9c-de1fcef9a482)

* 코드 긴 부분 컴포넌트화 코드 긴 부분 컴포넌트화 (메세지 영역을 처리하는 로직을 `messageArea` 컴포넌트로 따로 분리하였습니다.


## 리뷰어에게 한마디

수정할 부분이 있다면 작은 부분이라도 말씀해 주시면 감사하겠습니다!!
