### PR TITLE
[Refac] 로그아웃 버튼에 confirm  모달 적용

### DIFF
--- a/src/components/common/modalConfirm/index.tsx
+++ b/src/components/common/modalConfirm/index.tsx
@@ -53,7 +53,7 @@ const ModalConfirm = () => {
   )
 }
 const StyleConfirmWrapper = styled.div`
-  z-index: 1;
+  z-index: 999;
   display: flex;
   position: absolute;
   justify-content: center;

--- a/src/pages/myprofile/MyPage.tsx
+++ b/src/pages/myprofile/MyPage.tsx
@@ -9,6 +9,7 @@ import ProfileImage from '@/components/common/profileImage'
 import Spacing from '@/components/common/spacing'
 import { Text } from '@/components/common/text'
 import { axiosAPI } from '@/libs/apis/axios'
+import { useConfirmModal } from '@/libs/hooks/useConfirmModal'
 import useModal from '@/libs/hooks/useModal'
 import { userAtom } from '@/libs/store/userAtom'
 
@@ -16,6 +17,7 @@ const MyProfile = () => {
   const userData = useAtomValue(userAtom)
   const navigate = useNavigate()
   const { openModal } = useModal()
+  const { openConfirmModal } = useConfirmModal()
   const logoutMutation = useMutation(async () => await axiosAPI.post('/logout'), {
     onSuccess: () => {
       openModal({ content: '로그아웃 완료! 다음에 만나요 🙌', type: 'success' })
@@ -67,7 +69,12 @@ const MyProfile = () => {
           position: 'absolute',
           bottom: '20px',
         }}
-        onClick={Logout}
+        onClick={() =>
+          openConfirmModal({
+            confirmText: '로그아웃 하시겠습니까?',
+            okFunc: () => logoutMutation.mutate(),
+          })
+        }
       />
     </>
   )


### PR DESCRIPTION
## 이슈번호
<!-- - close 뒤에 이슈 달아주기 -->
- close #143 

## 작업내용 설명
<!-- 스크린샷 및 작업내용을 적어주세요 -->
<img width="300" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_PETTALK_Yrnana/assets/96521594/45cade6e-0a61-4dae-80fc-f90f81b1d644">

로그아웃 시 window.confirm 창에서 만들어둔 useConfirmModal훅으로 변경하였습니다!
Appbar 보다 confirm 창의 뒷배경이 더 위에 뜨도록 하기 위해 z-index를 더 키웠습니다.

## 리뷰어에게 한마디
<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->
