### PR TITLE
[Refac & Bug] 채팅 목록 페이지 리팩토링 및 버그 수정

### DIFF
--- a/src/pages/chattingList/ChattingList.tsx
+++ b/src/pages/chattingList/ChattingList.tsx
@@ -30,7 +30,9 @@ const ChattingList = () => {
     refetchIntervalInBackground: true,
     retry: 3,
     onSuccess: async (responseData: Conversation[]) => {
-      await MessageApi.READ_MESSAGE(responseData[responseData.length - 1].sender._id)
+      if (responseData.length > 0) {
+        await MessageApi.READ_MESSAGE(responseData[responseData.length - 1].sender._id)
+      }
     },
     cacheTime: 0,
   })

--- a/src/pages/chattingList/ChattingList.tsx
+++ b/src/pages/chattingList/ChattingList.tsx
@@ -146,6 +146,7 @@ const ChattingList = () => {
 }
 const StyleChattingListWrapper = styled.div`
   width: 100%;
+  height: 100%;
 `
 const StyleListRow = styled(FlexBox)`
   cursor: pointer;
@@ -157,11 +158,14 @@ const Stylehr = styled.hr`
 `
 const StyleSearchArea = styled(FlexBox)`
   text-align: center;
+  height: 100%;
   padding: 0px 20px;
 `
 const StyleChattingItem = styled.li`
   padding: 0px 20px;
   list-style: none;
+  max-height: calc(100% - 100px);
+  overflow-y: auto;
 `
 const StyleNoData = styled.div`
   text-align: center;

--- a/src/pages/chattingList/ChattingList.tsx
+++ b/src/pages/chattingList/ChattingList.tsx
@@ -113,7 +113,7 @@ const ChattingList = () => {
                   direction={'column'}
                   fullWidth={true}
                   gap={10}
-                  key={chat._id[1]}
+                  key={findOpponent(chat)._id}
                   onClick={() => {
                     moveChattingRoom(chat)
                   }}

--- a/src/pages/chattingList/ChattingList.tsx
+++ b/src/pages/chattingList/ChattingList.tsx
@@ -4,7 +4,6 @@ import { useAtomValue } from 'jotai'
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import Search from '@/assets/icons/Search'
 import defaultProfileImage from '@/assets/images/defaultProfileImage.png'
 import { FlexBox } from '@/components/common/flexBox'
 import Input from '@/components/common/input'
@@ -85,6 +84,10 @@ const ChattingList = () => {
     }
   }, [data])
 
+  useEffect(() => {
+    if (debouncedValue) fetchSearchData(debouncedValue)
+  }, [debouncedValue])
+
   if (isLoading) return <Loading></Loading>
 
   return (
@@ -100,9 +103,6 @@ const ChattingList = () => {
                 ref={searchInputRef}
                 onChange={handleSearchChat}
               />
-              {/* <StyleSearchIcon onClick={searchChattingList}>
-                <Search />
-              </StyleSearchIcon> */}
             </StyleSearchArea>
           </FlexBox>
           <Spacing size={30} />

--- a/src/pages/chattingList/ChattingList.tsx
+++ b/src/pages/chattingList/ChattingList.tsx
@@ -152,7 +152,7 @@ const StyleListRow = styled(FlexBox)`
   margin: 10px 0px;
 `
 const Stylehr = styled.hr`
-  border: 1px solid ${palette.GRAY300};
+  border: 1px solid ${palette.GRAY400};
   width: 100%;
 `
 const StyleSearchArea = styled(FlexBox)`


### PR DESCRIPTION
## 이슈번호

- close #135 
- close #125 

## 작업내용 설명

### Refac
- [x] 배경 이미지가 리스트의 경계선을 가리지 않도록 수정
     - https://www.notion.so/e0b0b9d31743461ab4145ad328ee57e2?pvs=4
- [x] 채팅 목록 페이지 스크롤 되도록 수정
     - https://www.notion.so/6f6f07b55b4940a1b01a2f2a02e235ac?pvs=4

<img width="482" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_PETTALK_Yrnana/assets/32586926/41fbb043-5a76-41ae-a80a-160f95c85363">


### Bug
- [x] `sender` 값이 없다고 뜨는 ts 에러 수정
     - https://www.notion.so/sender-undefined-74a46c821540428a8e0196bacdfbbb67?pvs=4
- [x] 채팅 목록 리스트 map 사용시 key 값이 같은 오류를 처리
     - https://www.notion.so/map-key-374c9dd89329458e9b243c61ca4b77b8
- [x] 채팅 목록 검색 바로 반영되도록 수정
     - https://www.notion.so/1c949317f88d4c708370290b4c043aea?pvs=4

## 리뷰어에게 한마디

* 검색 부분은 useEffect로 바로 반영되도록 처리 했슴다. 우선 채팅 페이지에만 적용해두었고 아래와 같은 방식으로 처리했습니다.

```tsx
useEffect(() => {
    if (debouncedValue) fetchSearchData(debouncedValue)
  }, [debouncedValue])
```

* @eugene028 님이 작성해주신 로직의 `debouncedValue` 값이 변함에 따라 화면에 로드되는 데이터를 변동하도록 수정했습니다.








