### PR TITLE
feature: 채널 데이터 개수 따라 슬라이더 화면 변경

### DIFF
--- a/src/components/channel/carousel/index.tsx
+++ b/src/components/channel/carousel/index.tsx
@@ -7,7 +7,7 @@ import { FlexBox } from '@/components/common/flexBox'
 import { Text } from '@/components/common/text'
 import { Channel } from '@/libs/apis/channel/channelType'
 import { palette } from '@/styles/palette'
-import { KeyOfPalette, KeyOfTypo } from '@/styles/theme'
+import { KeyOfPalette, KeyOfTypo, theme } from '@/styles/theme'
 
 interface CarouselProps extends ComponentProps<'div'> {
   images: string[]
@@ -56,18 +56,31 @@ const Carousel = ({
   return (
     <CarouselContainer justify={'flex-start'} direction={'column'}>
       <ImageSlider ref={sliderRef}>
-        {randomData.map((channel, index) => (
-          <CarouselItem key={channel._id}>
-            <Link to={`/posts/${channel._id}`} style={{ textDecoration: 'none' }}>
-              <Image src={images[index]} alt={'img test'} onError={addDefaultImg} />
-              <SpanWrapper>
-                <Text typo={channelTypo} color={channelColor}>
-                  {channel.name}
-                </Text>
-              </SpanWrapper>
-            </Link>
-          </CarouselItem>
-        ))}
+        {randomData.length ? (
+          randomData.map((channel, index) => (
+            <CarouselItem key={channel._id}>
+              <Link to={`/posts/${channel._id}`} style={{ textDecoration: 'none' }}>
+                <Image
+                  src={images[index % images.length]}
+                  alt={'이미지 없음'}
+                  onError={addDefaultImg}
+                />
+
+                <SpanWrapper>
+                  <Text typo={channelTypo} color={channelColor}>
+                    {channel.name}
+                  </Text>
+                </SpanWrapper>
+              </Link>
+            </CarouselItem>
+          ))
+        ) : (
+          <NoneImgArea>
+            <Text typo={'Body_20'} color={'GRAY600'}>
+              {'아직 채널이 없습니다. 채널을 생성해주세요!'}
+            </Text>
+          </NoneImgArea>
+        )}
       </ImageSlider>
 
       <PageIndicator>
@@ -87,6 +100,7 @@ const CarouselContainer = styled(FlexBox)`
   overflow: hidden;
   width: 100%;
   position: relative;
+  background-color: ${({ theme }) => theme.palette.GRAY100};
 `
 
 const CarouselItem = styled.div`
@@ -102,6 +116,7 @@ const SpanWrapper = styled.div`
 
 const ImageSlider = styled.div`
   display: flex;
+  width: 100%;
   transition: transform 0.3s linear;
   will-change: transform;
   backface-visibility: hidden;
@@ -114,6 +129,12 @@ const Image = styled.img`
   object-fit: cover;
   opacity: 0.7;
   content-visibility: auto;
+`
+
+const NoneImgArea = styled(FlexBox)`
+  width: 100%;
+  height: 190px;
+  /* background-color: ${({ theme }) => theme.palette.GRAY100}; */
 `
 
 const PageIndicator = styled(FlexBox)`

--- a/src/components/channel/channelSlider/index.tsx
+++ b/src/components/channel/channelSlider/index.tsx
@@ -15,6 +15,7 @@ interface ChannelSliderProps extends ComponentProps<'div'> {
 
 const ChannelSlider = ({ data: channelListData }: ChannelSliderProps) => {
   const [imagesLoaded, setImagesLoaded] = useState(false)
+  const imgSliceIndex = channelListData.length >= 4 ? 4 : channelListData.length
 
   // 이미지 프리로딩
   useEffect(() => {
@@ -44,7 +45,10 @@ const ChannelSlider = ({ data: channelListData }: ChannelSliderProps) => {
   return (
     <CarouselWrapper>
       {imagesLoaded ? (
-        <Carousel images={[pic1, pic2, pic3, pic4]} data={channelListData} />
+        <Carousel
+          images={[pic1, pic2, pic3, pic4].slice(0, imgSliceIndex)}
+          data={channelListData}
+        />
       ) : (
         <Skeleton></Skeleton>
       )}
@@ -57,7 +61,6 @@ const CarouselWrapper = styled.div`
   height: 190px;
   overflow: hidden;
   border-radius: 10px;
-  background-color: ${({ theme }) => theme.palette.WHITE};
 `
 
 export default ChannelSlider


### PR DESCRIPTION
## 이슈번호

<!-- - close 뒤에 이슈 달아주기 -->

- close #160 

## 작업내용 설명

메인 페이지에서 채널 개수에 따른 슬라이더 화면을 조정했습니다.

* 채널 0개
![image](https://github.com/prgrms-fe-devcourse/FEDC4_PETTALK_Yrnana/assets/32586926/150e31ef-f26a-44fd-84d7-ccbea62f2fab)

* 채널 1~3개 (개수에 따라 슬라이더 밑 부분에 '.' 개수 변경)
![image](https://github.com/prgrms-fe-devcourse/FEDC4_PETTALK_Yrnana/assets/32586926/e3e0ea2e-45d7-459c-bf52-b007b47472b8)

* 채널 4개이상 (슬라이더 4개까지 - 기존이랑 변동 x)
![image](https://github.com/prgrms-fe-devcourse/FEDC4_PETTALK_Yrnana/assets/32586926/ac88af62-6a4a-4831-ac9c-a5b62bfdcc0e)


## 리뷰어에게 한마디

* 생각해 보니 제가 채널 4개 이상일 때 작업을 시작해서 채널이 없을 경우, 1~3개일 경우 처리를 안 해두었습니다...  죄송함다 ㅠㅠ
* 한 번 채널을 쫙 생성해둔 후 4개 이하로 내려갈 일이 없을 것 같긴 하지만 우선 따로 간단하게 처리를 해두었습니다. 
* 채널 4개 이상일 경우는 기존 로직과 동일하고 0~4개 미만일 경우의 처리만 추가해두었습니다! 
